### PR TITLE
Support Chrome extension shortcuts

### DIFF
--- a/background.js
+++ b/background.js
@@ -165,6 +165,14 @@ const server = new Server({
     state.setKeysetId(args.keysetId);
     await cache.flush();
   },
+  'listCommandCombos': async (args) => {
+    const options = await cache.getOptions();
+    return options.listCommandCombos();
+  },
+  'setCommandCombo': async (args) => {
+    const options = await cache.getOptions();
+    options.setCommandCombo(args.command, args.combo);
+  },
   'pinTab': async (args) => {
     const [currentTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
     if (!currentTab) {

--- a/background.js
+++ b/background.js
@@ -5,13 +5,6 @@ import combos from './combos.js';
 const GLOBAL_KEYSET_ID = 0;
 const HISTORY_KEY = 'Backspace';
 
-const COMMAND_COMBOS = {
-  "command-01": "ga",
-  "command-02": "pa",
-  "command-03": "gb",
-  "command-04": "pb",
-}
-
 const cache = new Cache();
 
 async function findTab(pin, keyRef) {
@@ -265,7 +258,8 @@ const comboTrie = function() {
 
 chrome.commands.onCommand.addListener(async (command) => {
   console.log(`Command triggered: ${command}`);
-  const combo = COMMAND_COMBOS[command];
+  const options = await cache.getOptions();
+  const combo = options.getCommandCombo(command);
   if (!combo) {
     console.log(`No key sequence registered for ${command}.`);
     return;

--- a/background.js
+++ b/background.js
@@ -276,4 +276,4 @@ chrome.commands.onCommand.addListener(async (command) => {
   if (result) {
     await result.action(result.args);
   }
-})
+});

--- a/background.js
+++ b/background.js
@@ -4,6 +4,13 @@ import { Cache } from './storage.js';
 const GLOBAL_KEYSET_ID = 0;
 const HISTORY_KEY = 'Backspace';
 
+const COMMAND_KEYS = {
+  "command-01": "KeyA",
+  "command-02": "KeyS",
+  "command-03": "KeyD",
+  "command-04": "KeyF",
+}
+
 const cache = new Cache();
 
 async function findTab(pin, keyRef) {
@@ -221,3 +228,17 @@ const server = new Server({
 });
 
 chrome.runtime.onMessage.addListener(server.serve.bind(server));
+
+chrome.commands.onCommand.addListener(async (command) => {
+  console.log(`Command triggered: ${command}`);
+  const key = COMMAND_KEYS[command];
+  if (!key) {
+    throw new UserException(`No key registered for ${command}.`);
+  }
+  const state = await cache.getState();
+  const result = server.execute({
+    command: 'focusTab',
+    args: { key: key, keysetId: state.data.keysetId, options: {} },
+  });
+  console.log(`Result: ${result}`);
+})

--- a/combos.js
+++ b/combos.js
@@ -1,0 +1,193 @@
+import { htmlToKeyCode } from './keys.js';
+import { UserException } from './lpc.js';
+
+// Special character in key combinations to represent a key ref (<key> or <digit><key>).
+const COMBO_ARG_KEY_REF = '@';
+const COMBO_ARG_KEYSET = '#';
+
+// A ComboTrie stores key combinations in a trie and associates them with actions.
+class ComboTrie {
+  constructor() {
+    this.root = {};
+  }
+  // Inserts the combination into the trie and associates a value with it.
+  addCombo(code, action) {
+    let node = this.root;
+    for (let i = 0; i < code.length; i++) {
+      const char = code[i];
+      if (char in node) {
+        node = node[char];
+      } else {
+        const child = {};
+        node[char] = child;
+        node = child;
+      }
+    }
+    node.action = action;
+  }
+  // Attempts to match the input against all registered combos.
+  // If a combo has been matched, this method returns the registered value and parsed key ref.
+  // If no combo has been completed yet, `null` is returned.
+  // If no combo matches the input, an exception is raised.
+  match(input) {
+    let node = this.root;
+    let keyRefBuilder = {};
+    const args = [];
+    for (let i = 0; i < input.length; i++) {
+      const char = input[i];
+      if (COMBO_ARG_KEY_REF in node) {
+        if (char.match(/\d/)) {
+          if (keyRefBuilder.keysetId != null) {
+            throw new UserException(`Multiple keyset IDs in ${input}.`);
+          }
+          keyRefBuilder.keysetId = Number.parseInt(char);
+          continue;
+        }
+        if (char.match(/[a-zA-Z\[\]\\;',./]/)) {
+          if (keyRefBuilder.key != null) {
+            throw new UserException(`Multiple keys in ${input}.`);
+          }
+          keyRefBuilder.key = htmlToKeyCode.get(char.toUpperCase());
+          args.push(keyRefBuilder);
+          keyRefBuilder = {};
+          node = node[COMBO_ARG_KEY_REF];
+          continue;
+        }
+      } else if (COMBO_ARG_KEYSET in node) {
+        if (char.match(/\d/)) {
+          const keysetId = Number.parseInt(char);
+          args.push({ keysetId });
+          node = node[COMBO_ARG_KEYSET];
+          continue;
+        }
+      } if (char in node) {
+        node = node[char];
+        continue;
+      }
+      throw new UserException(`Unexpected character at position ${i} in "${input}".`);
+    }
+    if (node.action) {
+      return {
+        action: node.action,
+        args: args,
+      };
+    }
+    return null;
+  }
+}
+
+
+const defaultComboDescriptors = function() {
+  const combos = new Array();
+  combos.push({
+    sequence: 'g@',
+    descriptor: {
+      method: 'focusTab',
+      argTransformer: ([keyRef], withDefaultKeysetId) => withDefaultKeysetId(keyRef),
+      closePopup: true,
+    },
+  });
+  combos.push({
+    sequence: 'G@',
+    descriptor: {
+      method: 'focusTab',
+      argTransformer: function([keyRef], withDefaultKeysetId) {
+        return { ...withDefaultKeysetId(keyRef), options: { summon: true }};
+      },
+      closePopup: true,
+    },
+  });
+  combos.push({
+    sequence: 'f@',
+    descriptor: {
+      method: 'focusTab',
+      argTransformer: function([keyRef], withDefaultKeysetId) {
+        return { ...withDefaultKeysetId(keyRef), options: { recreate: true }};
+      },
+      closePopup: true,
+    },
+  });
+  combos.push({
+    sequence: 'r@',
+    descriptor: {
+      method: 'focusTab',
+      argTransformer: function([keyRef], withDefaultKeysetId) {
+        return { ...withDefaultKeysetId(keyRef), options: { reset: true }};
+      },
+      closePopup: true,
+    },
+  });
+  combos.push({
+    sequence: 'x@',
+    descriptor: {
+      method: 'closeTab',
+      argTransformer: ([keyRef], withDefaultKeysetId) => withDefaultKeysetId(keyRef),
+    },
+  });
+  combos.push({
+    sequence: 'm@@',
+    descriptor: {
+      method: 'updatePin',
+      argTransformer: function([srcKeyRef, dstKeyRef], withDefaultKeysetId) {
+        return {
+          ...withDefaultKeysetId(srcKeyRef),
+          updates: withDefaultKeysetId(dstKeyRef),
+        };
+      },
+    },
+  });
+  combos.push({
+    sequence: 'd@',
+    descriptor: {
+      method: 'removePin',
+      argTransformer: ([keyRef], withDefaultKeysetId) => withDefaultKeysetId(keyRef),
+    },
+  });
+  combos.push({
+    sequence: 'D#',
+    descriptor: {
+      method: 'clearKeyset',
+      argTransformer: ([partialKeyRef], withDefaultKeysetId) => partialKeyRef,
+    },
+  });
+  combos.push({
+    sequence: 'DD',
+    descriptor: {
+      method: 'clearKeyset',
+      argTransformer: (noArgs, withDefaultKeysetId) => withDefaultKeysetId({}),
+    },
+  });
+  combos.push({
+    sequence: 'p@',
+    descriptor: {
+      method: 'pinTab',
+      argTransformer: function([keyRef], withDefaultKeysetId) {
+        return { ...withDefaultKeysetId(keyRef), options: { pinScope: 'origin' }};
+      },
+      closePopup: true,
+    },
+  });
+  combos.push({
+    sequence: 'P@',
+    descriptor: {
+      method: 'pinTab',
+      argTransformer: function([keyRef], withDefaultKeysetId) {
+        return { ...withDefaultKeysetId(keyRef), options: { pinScope: 'page' }};
+      },
+      closePopup: true,
+    },
+  });
+  return combos;
+}();
+
+function createDefaultComboTrie(buildAction) {
+  const trie = new ComboTrie();
+  defaultComboDescriptors.forEach((c) => {
+    trie.addCombo(c.sequence, buildAction(c.descriptor));
+  });
+  return trie
+}
+
+export default {
+  createDefaultTrie: createDefaultComboTrie,
+};

--- a/common.css
+++ b/common.css
@@ -33,6 +33,10 @@ button:hover, button:focus {
   background-color: #d3d3d3;
 }
 
+/* Fonts */
+.font-monospace {
+  font-family: monospace;
+}
 /* Layout */
 .flex {
   display: flex;

--- a/common.css
+++ b/common.css
@@ -63,6 +63,9 @@ button:hover, button:focus {
 .margin-top {
   margin-top: 5px;
 }
+.margin-top-double {
+  margin-top: 10px;
+}
 .bullets-none {
   list-style-type: none;
 }

--- a/lpc.js
+++ b/lpc.js
@@ -32,13 +32,17 @@ export class Server {
     this.messageHandlers = messageHandlers;
   }
 
-  serve(msg, sender, respond) {
-    console.log(`Incoming message: ${JSON.stringify(msg)}`);
+  async execute(msg) {
     const handler = this.messageHandlers[msg.command];
     if (!handler) {
       throw new UserException(`No handler for message: ${JSON.stringify(msg)}`);
     }
-    handler(msg.args).then((result) => {
+    return handler(msg.args);
+  }
+
+  serve(msg, sender, respond) {
+    console.log(`Incoming message: ${JSON.stringify(msg)}`);
+    this.execute(msg).then((result) => {
       const response = { success: true, result };
       console.log(`Response: ${JSON.stringify(response)}`);
       respond(response);

--- a/manifest.json
+++ b/manifest.json
@@ -30,5 +30,113 @@
     "32": "images/icon-32.png",
     "48": "images/icon-48.png",
     "128": "images/icon-128.png"
+  },
+  "commands": {
+    "command-01": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+A",
+        "mac": "Alt+Shift+A"
+      },
+      "description": "Command Slot 01"
+    },
+    "command-02": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Alt+Shift+S"
+      },
+      "description": "Command Slot 02"
+    },
+    "command-03": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+D",
+        "mac": "Alt+Shift+D"
+      },
+      "description": "Command Slot 03"
+    },
+    "command-04": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+F",
+        "mac": "Alt+Shift+F"
+      },
+      "description": "Command Slot 04"
+    },
+    "command-05": {
+      "description": "Command Slot 05"
+    },
+    "command-06": {
+      "description": "Command Slot 06"
+    },
+    "command-07": {
+      "description": "Command Slot 07"
+    },
+    "command-08": {
+      "description": "Command Slot 08"
+    },
+    "command-09": {
+      "description": "Command Slot 09"
+    },
+    "command-10": {
+      "description": "Command Slot 10"
+    },
+    "command-11": {
+      "description": "Command Slot 11"
+    },
+    "command-12": {
+      "description": "Command Slot 12"
+    },
+    "command-13": {
+      "description": "Command Slot 13"
+    },
+    "command-14": {
+      "description": "Command Slot 14"
+    },
+    "command-15": {
+      "description": "Command Slot 15"
+    },
+    "command-16": {
+      "description": "Command Slot 16"
+    },
+    "command-17": {
+      "description": "Command Slot 17"
+    },
+    "command-18": {
+      "description": "Command Slot 18"
+    },
+    "command-19": {
+      "description": "Command Slot 19"
+    },
+    "command-20": {
+      "description": "Command Slot 20"
+    },
+    "command-21": {
+      "description": "Command Slot 21"
+    },
+    "command-22": {
+      "description": "Command Slot 22"
+    },
+    "command-23": {
+      "description": "Command Slot 23"
+    },
+    "command-24": {
+      "description": "Command Slot 24"
+    },
+    "command-25": {
+      "description": "Command Slot 25"
+    },
+    "command-26": {
+      "description": "Command Slot 26"
+    },
+    "command-27": {
+      "description": "Command Slot 27"
+    },
+    "command-28": {
+      "description": "Command Slot 28"
+    },
+    "command-29": {
+      "description": "Command Slot 29"
+    },
+    "command-30": {
+      "description": "Command Slot 30"
+    }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
   "side_panel": {
     "default_path": "side-panel.html"
   },
+  "options_page": "options.html",
   "background": {
     "service_worker": "background.js",
     "type": "module"
@@ -33,31 +34,15 @@
   },
   "commands": {
     "command-01": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+A",
-        "mac": "Alt+Shift+A"
-      },
       "description": "Command Slot 01"
     },
     "command-02": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+S",
-        "mac": "Alt+Shift+S"
-      },
       "description": "Command Slot 02"
     },
     "command-03": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+D",
-        "mac": "Alt+Shift+D"
-      },
       "description": "Command Slot 03"
     },
     "command-04": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+F",
-        "mac": "Alt+Shift+F"
-      },
       "description": "Command Slot 04"
     },
     "command-05": {

--- a/manifest.json
+++ b/manifest.json
@@ -34,16 +34,29 @@
   },
   "commands": {
     "command-01": {
-      "description": "Command Slot 01"
+      "description": "Command Slot 01",
+      "suggested_key": {
+        "default": "Alt+Shift+A"
+      }
     },
     "command-02": {
-      "description": "Command Slot 02"
+      "description": "Command Slot 02",
+      "suggested_key": {
+        "default": "Alt+Shift+S"
+      }
     },
     "command-03": {
-      "description": "Command Slot 03"
+      "description": "Command Slot 03",
+      "suggested_key": {
+        "default": "Alt+Shift+D"
+      }
+
     },
     "command-04": {
-      "description": "Command Slot 04"
+      "description": "Command Slot 04",
+      "suggested_key": {
+        "default": "Alt+Shift+F"
+      }
     },
     "command-05": {
       "description": "Command Slot 05"

--- a/options.css
+++ b/options.css
@@ -1,0 +1,5 @@
+.shortcut-grid {
+  display: grid;
+  grid-template-columns: 150px 150px 100px;
+  row-gap: 1ex;
+}

--- a/options.css
+++ b/options.css
@@ -3,3 +3,14 @@
   grid-template-columns: 150px 150px 100px;
   row-gap: 1ex;
 }
+
+.options-card {
+  margin-left: auto;
+  margin-right: auto;
+  padding: 15px 20px;
+  border-radius: 10px;
+  box-shadow: 1px 1px 4px 0px #797878;
+  background-color: #eeeeee;
+  max-width: 500px;
+  width: 90%;
+}

--- a/options.html
+++ b/options.html
@@ -8,8 +8,8 @@
 <body>
   <section>
     <h1>Shortcut Actions</h1>
-    <p class="margin-top">This options page lets you assign command combos to command slots. Before assigning command combos, you'll need to assign shortcuts to however many command slots you'd like to use in Chrome's shortcut menu. You can type in <code>chrome://extensions/shortcuts</code> in the address bar to get to that menu.</p>
-    <div class="shortcut-grid margin-top" id="shortcutGrid"></div>
+    <p class="margin-top-double">This options page lets you assign command combos to command slots. Before assigning command combos, you'll need to assign shortcuts to however many command slots you'd like to use in Chrome's shortcut menu. You can type in <code>chrome://extensions/shortcuts</code> in the address bar to get to that menu.</p>
+    <div class="options-card shortcut-grid margin-top-double" id="shortcutGrid"></div>
   </section>
 
   <!-- Toast -->

--- a/options.html
+++ b/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Hot Tab Options</title>
+  <link rel="stylesheet" href="./common.css">
+  <link rel="stylesheet" href="./options.css">
+</head>
+<body>
+  <section>
+    <h1>Shortcut Actions</h1>
+    <p class="margin-top">This options page lets you assign command combos to command slots. Before assigning command combos, you'll need to assign shortcuts to however many command slots you'd like to use in Chrome's shortcut menu. You can type in <code>chrome://extensions/shortcuts</code> in the address bar to get to that menu.</p>
+    <div class="shortcut-grid margin-top" id="shortcutGrid"></div>
+  </section>
+
+  <!-- Toast -->
+  <div id="toast" class="toast hidden">
+    <button id="toast-close">&#x2715;</button>
+    <span id="toast-content">Test</span>
+  </div>
+
+  <script src="options.js" type="module"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,45 @@
+import { Client } from './lpc.js';
+import toast from './toast.js';
+
+const background = new Client([]);
+
+async function refereshShortcuts() {
+  const shortcutGrid = document.getElementById('shortcutGrid');
+  const commands = await chrome.commands.getAll();
+  commands
+    .filter(c => c.name.match(/^command-\d{2}$/))
+    .sort((a, b) => a.description.localeCompare(b.description))
+    .forEach((c) => {
+      // Add name.
+      const title = document.createElement('span');
+      title.innerText = c.description;
+      shortcutGrid.appendChild(title);
+      // Add shortcut.
+      const shortcutDiv = document.createElement('div');
+      if (c.shortcut) {
+        // The shortcut string is platform dependent: ⌃⇧Y vs Ctrl+Shift+Y
+        const keys = c.shortcut.includes('+') ? c.shortcut.split('+') : c.shortcut.split('');
+        for (let i = 0; i < keys.length; i++) {
+          const keySpan = document.createElement('span');
+          keySpan.classList.add('key', 'key-inline');
+          keySpan.classList.toggle('margin-left', i > 0);
+          keySpan.innerText = keys[i];
+          shortcutDiv.appendChild(keySpan);
+        }
+      } else {
+        const keySpan = document.createElement('span');
+        keySpan.innerText = '(no shortcut)';
+        shortcutDiv.appendChild(keySpan);
+      }
+      shortcutGrid.appendChild(shortcutDiv);
+      // Add key combo.
+      const comboInput = document.createElement('input');
+      comboInput.classList.add('font-monospace');
+      comboInput.type = 'text';
+      // TODO: Set stored option value.
+      // TODO: Store changed input.
+      shortcutGrid.appendChild(comboInput);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', toast.catch(refereshShortcuts));

--- a/options.js
+++ b/options.js
@@ -1,11 +1,12 @@
 import { Client } from './lpc.js';
 import toast from './toast.js';
 
-const background = new Client([]);
+const background = new Client(['listCommandCombos', 'setCommandCombo']);
 
 async function refereshShortcuts() {
   const shortcutGrid = document.getElementById('shortcutGrid');
   const commands = await chrome.commands.getAll();
+  const combos = await background.listCommandCombos();
   commands
     .filter(c => c.name.match(/^command-\d{2}$/))
     .sort((a, b) => a.description.localeCompare(b.description))
@@ -36,8 +37,13 @@ async function refereshShortcuts() {
       const comboInput = document.createElement('input');
       comboInput.classList.add('font-monospace');
       comboInput.type = 'text';
-      // TODO: Set stored option value.
-      // TODO: Store changed input.
+      comboInput.value = combos[c.name];
+      comboInput.addEventListener('input', toast.catch(async (event) => {
+        return background.setCommandCombo({
+          command: c.name,
+          combo: event.target.value,
+        });
+      }));
       shortcutGrid.appendChild(comboInput);
     });
 }

--- a/storage.js
+++ b/storage.js
@@ -9,10 +9,46 @@ const defaultKeysets = Array(10).keys().reduce((acc, val) => {
   return acc;
 }, []);
 
+const defaultOptions = {
+  commandCombos: {
+    "command-01": "ga",
+    "command-02": "",
+    "command-03": "",
+    "command-04": "",
+    "command-05": "",
+    "command-06": "",
+    "command-07": "",
+    "command-08": "",
+    "command-09": "",
+    "command-10": "",
+    "command-11": "",
+    "command-12": "",
+    "command-13": "",
+    "command-14": "",
+    "command-15": "",
+    "command-16": "",
+    "command-17": "",
+    "command-18": "",
+    "command-19": "",
+    "command-20": "",
+    "command-21": "",
+    "command-22": "",
+    "command-23": "",
+    "command-24": "",
+    "command-25": "",
+    "command-26": "",
+    "command-27": "",
+    "command-28": "",
+    "command-29": "",
+    "command-30": "",
+  },
+};
+
 export class Cache {
   constructor() {
     this.state = null;
     this.keysets = null;
+    this.options = null;
   }
   async getState() {
     if (this.state === null) {
@@ -27,6 +63,13 @@ export class Cache {
       this.keysets = new Keysets(loaded.keysets);
     }
     return this.keysets;
+  }
+  async getOptions() {
+    if (this.options === null) {
+      const loaded = await chrome.storage.local.get('options');
+      this.options = new Options(loaded.options);
+    }
+    return this.options;
   }
   async flush() {
     let p = [];
@@ -146,5 +189,28 @@ class Keyset {
     const ref = this.findRef(key, /*mustExist=*/true);
     this.keysets.remove(ref);
     return ref.keysetId;
+  }
+}
+
+class Options {
+  constructor(data) {
+    this.data = {...defaultOptions, ...data};
+    this.dirty = false;
+  }
+  listCommandCombos() {
+    return this.data.commandCombos;
+  }
+  getCommandCombo(command) {
+    return this.data.commandCombos[command];
+  }
+  setCommandCombo(command, combo) {
+    this.data.commandCombos[command] = combo;
+    this.dirty = true;
+  }
+  async flush() {
+    if (this.dirty) {
+      await chrome.storage.local.set({'options': this.data});
+      this.dirty = false;
+    }
   }
 }

--- a/storage.js
+++ b/storage.js
@@ -79,6 +79,9 @@ export class Cache {
     if (this.keysets) {
       p.push(this.keysets.flush());
     }
+    if (this.options) {
+      p.push(this.options.flush());
+    }
     await Promise.all(p);
   }
 }

--- a/storage.js
+++ b/storage.js
@@ -12,9 +12,9 @@ const defaultKeysets = Array(10).keys().reduce((acc, val) => {
 const defaultOptions = {
   commandCombos: {
     "command-01": "ga",
-    "command-02": "",
-    "command-03": "",
-    "command-04": "",
+    "command-02": "gs",
+    "command-03": "gd",
+    "command-04": "gf",
     "command-05": "",
     "command-06": "",
     "command-07": "",


### PR DESCRIPTION
As described in issue #4, this PR allows the use of Chrome shortcuts to use Hot Tab without going via the popup window. But instead of associating shortcuts with keys, shortcuts instead trigger user-defined command combos, making it a rather versatile tool. As a downside, this approach requires users to think how they'd like to use shortcuts and then create that setup. But since Chrome allows at most four suggested shortcut key combinations, it's not possible to ship an intricate setup anyway.